### PR TITLE
Consider Widening Rollup Peer Range Semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	},
 	"peerDependencies": {
 		"vite": "^3.1.4",
-		"rollup": "~2.79.1"
+		"rollup": "^2.79.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^29.1.1",


### PR DESCRIPTION
Hi! Thank you for creating this library. Very useful!

In my use case I have vite `^3.1.4` installed, and the newest published versions of vite are resolving to 2.79.1, causing strict peer dependency checks to fail (for instance, with pnpm):

```
 ERR_PNPM_PEER_DEP_ISSUES  Unmet peer dependencies

gui
└─┬ vite-plugin-singlefile 0.12.1
  └── ✕ unmet peer rollup@~2.78.0: found 2.79.1
```

The plugin seems to work well with the newer rollup, I wonder if it would be a good idea to widen the peer range to include minor versions?

Have a nice day,
nathan